### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/tests/CalculateTest.php
+++ b/tests/CalculateTest.php
@@ -19,14 +19,14 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for functions.
  *
  * @package PhpMyAdmin-test
  */
-
-
-class EvaluateTest extends PHPUnit_Framework_TestCase
+class EvaluateTest extends TestCase
 {
     /**
      * @dataProvider getEquations


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).